### PR TITLE
Additional endpoints + Fix middelware 

### DIFF
--- a/src/controllers/ai.py
+++ b/src/controllers/ai.py
@@ -12,7 +12,7 @@ async def generate(payload: GenerateRequest) -> GenerateResponse:
     now = datetime.now(timezone.utc)
     return GenerateResponse(
         conversation_id=payload.conversation_id,
-        content=payload.content,
+        content="AI response here",
         type=MessageType.ai,
         created_at=now,
         updated_at=now,

--- a/src/controllers/ai.py
+++ b/src/controllers/ai.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timezone
+
+from fastapi import APIRouter
+
+from src.schemas.ai import GenerateRequest, GenerateResponse, MessageType
+
+router = APIRouter(prefix="/api/v1", tags=["ai"])
+
+
+@router.post("/generate", response_model=GenerateResponse)
+async def generate(payload: GenerateRequest) -> GenerateResponse:
+    now = datetime.now(timezone.utc)
+    return GenerateResponse(
+        conversation_id=payload.conversation_id,
+        content=payload.content,
+        type=MessageType.ai,
+        created_at=now,
+        updated_at=now,
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import logging
 from fastapi import FastAPI
+from src.controllers.ai import router as ai_router
 from src.middlewares.correlation_id import CorrelationIDMiddleware
 from src.middlewares.error_handler import global_exception_handler
 from src.middlewares.events import EventMiddleware
@@ -11,10 +12,21 @@ logging.getLogger("starlette.middleware.errors").setLevel(logging.CRITICAL)
 # Setup FastAPI app and include middleware and exception handler
 app = FastAPI()
 app.add_exception_handler(Exception, global_exception_handler)
-app.add_middleware(CorrelationIDMiddleware)
 app.add_middleware(EventMiddleware)
+app.add_middleware(CorrelationIDMiddleware)
+app.include_router(ai_router)
 
 
 @app.get("/")
 async def main():
     return "Hello from ai-server!"
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+async def ready():
+    return {"status": "ok"}

--- a/src/main.py
+++ b/src/main.py
@@ -12,8 +12,8 @@ logging.getLogger("starlette.middleware.errors").setLevel(logging.CRITICAL)
 # Setup FastAPI app and include middleware and exception handler
 app = FastAPI()
 app.add_exception_handler(Exception, global_exception_handler)
-app.add_middleware(EventMiddleware)
 app.add_middleware(CorrelationIDMiddleware)
+app.add_middleware(EventMiddleware)
 app.include_router(ai_router)
 
 

--- a/src/middlewares/correlation_id.py
+++ b/src/middlewares/correlation_id.py
@@ -4,7 +4,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 
 class CorrelationIDMiddleware(BaseHTTPMiddleware):
-    "Middleware to add a correlation ID to each response for tracing purposes."
+    """Middleware to add a correlation ID to each response for tracing purposes."""
 
     async def dispatch(self, request: Request, call_next):
         correlation_id = request.headers.get("X-Correlation-ID", str(uuid.uuid4()))

--- a/src/schemas/ai.py
+++ b/src/schemas/ai.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class MessageType(str, Enum):
+    ai = "ai"
+    user = "user"
+
+
+class GenerateRequest(BaseModel):
+    conversation_id: str
+    content: str
+
+
+class GenerateResponse(BaseModel):
+    conversation_id: str
+    content: str
+    type: MessageType
+    created_at: datetime
+    updated_at: datetime


### PR DESCRIPTION
Fixed middleware order because it was throwing:
```
 Error occurred but no wide_event available: INTERNAL_ERROR - An unexpected error occurred
INFO:     127.0.0.1:53183 - "POST /api/v1/generate HTTP/1.1" 500 Internal Server Error
```

Added additional endpoints:
- /health
- /ready
- /generate (placeholder)

Added schemas for  /generate endpoint:
- MessageType
- GenerateRequest
- GenerateResponse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI generation endpoint
  * Added health check endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->