### PR TITLE
fix type annotation for type

### DIFF
--- a/src/models/message.py
+++ b/src/models/message.py
@@ -33,7 +33,7 @@ class Message(Base):
         nullable=False,
     )
     content = Column(Text, nullable=False)
-    type = Column(SQLEnum(MessageType), nullable=False)
+    type: Column[str] = Column(SQLEnum(MessageType), nullable=False)
     created_at = Column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),


### PR DESCRIPTION
Add type annotation fix for type. 

```
src/models/message.py:36: error: Need type annotation for "type"  [var-annotated]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality and type system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->