### PR TITLE
Fix Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
           service: ${{ vars.CLOUD_RUN_SERVICE }}
           region: ${{ vars.GCP_REGION }}
           image: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.ARTIFACT_REGISTRY_REPO }}/ai-server:${{ github.sha }}
+          port: 8000
           secrets: |
             DATABASE_URL=PSYCOPG_DATABASE_URL:latest
             AI_PROVIDER_API_KEY=AI_PROVIDER_API_KEY:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
           service: ${{ vars.CLOUD_RUN_SERVICE }}
           region: ${{ vars.GCP_REGION }}
           image: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.ARTIFACT_REGISTRY_REPO }}/ai-server:${{ github.sha }}
-          port: 8000
+          flags: '--port=8000'
           secrets: |
             DATABASE_URL=PSYCOPG_DATABASE_URL:latest
             AI_PROVIDER_API_KEY=AI_PROVIDER_API_KEY:latest


### PR DESCRIPTION
Added default port 8000 to deploy.yml. Google cloud defaults to 8080 if one is not given.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to explicitly set the service listening port to 8000, ensuring deployed instances use the correct network port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->