### PR TITLE
Remove AI_PROVIDER_BASE_URL from secrets in deploy and staging workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,6 @@ jobs:
           secrets: |
             DATABASE_URL=PSYCOPG_DATABASE_URL:latest
             AI_PROVIDER_API_KEY=AI_PROVIDER_API_KEY:latest
-            AI_PROVIDER_BASE_URL=AI_PROVIDER_BASE_URL:latest
             AI_PROVIDER_MODEL=AI_PROVIDER_MODEL:latest
             AUTH_URL=AUTH_URL:latest
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -57,5 +57,4 @@ jobs:
             AXIOM_INGEST_DATASET=ai-server-events-staging
           secrets: |
             AI_PROVIDER_API_KEY=AI_PROVIDER_API_KEY:latest
-            AI_PROVIDER_BASE_URL=AI_PROVIDER_BASE_URL:latest
             AI_PROVIDER_MODEL=AI_PROVIDER_MODEL:latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cloud Run deployment configuration by removing an unused environment variable from the deployment pipeline, streamlining the deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->