### PR TITLE
Chore/sqlalchemy mapped migration

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -40,7 +40,7 @@ target_metadata = Base.metadata
 # ... etc.
 
 # Only include tables that are managed by this service
-MANAGED_TABLES = {"message", "summary"}
+MANAGED_TABLES = {"message", "summary", "sentiment"}
 
 
 def include_object(obj, name, type_, reflected, compare_to):

--- a/alembic/versions/b3066707dfbe_add_cascade_for_sentiment.py
+++ b/alembic/versions/b3066707dfbe_add_cascade_for_sentiment.py
@@ -1,0 +1,45 @@
+"""add cascade for sentiment
+
+Revision ID: b3066707dfbe
+Revises: 2fa0adcca67d
+Create Date: 2026-04-17 16:06:03.598147
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b3066707dfbe"
+down_revision: Union[str, Sequence[str], None] = "2fa0adcca67d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "sentiment_conversation_id_fkey", "sentiment", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "sentiment_conversation_id_fkey",
+        "sentiment",
+        "conversation",
+        ["conversation_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "sentiment_conversation_id_fkey", "sentiment", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "sentiment_conversation_id_fkey",
+        "sentiment",
+        "conversation",
+        ["conversation_id"],
+        ["id"],
+    )

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -5,6 +5,7 @@ from .conversation import Conversation
 from .message import Message, MessageType
 from .user import User
 from .summary import Summary
+from .sentiment import Sentiment
 
 __all__ = [
     "Base",
@@ -13,4 +14,5 @@ __all__ = [
     "MessageType",
     "User",
     "Summary",
+    "Sentiment",
 ]

--- a/src/models/base.py
+++ b/src/models/base.py
@@ -1,7 +1,8 @@
-from sqlalchemy import UUID, Column
-from sqlalchemy.orm import DeclarativeBase
+import uuid
+
+from sqlalchemy import UUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
 class Base(DeclarativeBase):
-    id = Column(UUID, primary_key=True)
-    pass
+    id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)

--- a/src/models/conversation.py
+++ b/src/models/conversation.py
@@ -1,9 +1,7 @@
 """Conversation model STUB to allow for foreign key relationships in Message model."""
 
-from sqlalchemy import UUID, Column
 from .base import Base
 
 
 class Conversation(Base):
     __tablename__ = "conversation"
-    id = Column(UUID, primary_key=True)

--- a/src/models/message.py
+++ b/src/models/message.py
@@ -1,36 +1,33 @@
-from datetime import datetime, timezone
 import uuid
-
-from sqlalchemy.orm import Mapped, mapped_column
-from .base import Base
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     UUID,
-    Column,
     Text,
     DateTime,
     ForeignKey,
     Enum as SQLEnum,
     Index,
 )
+from sqlalchemy.orm import Mapped, mapped_column
 
+from .base import Base
 from src.schemas.message_model import MessageType
 
 
 class Message(Base):
     __tablename__ = "message"
-    id = Column(UUID, primary_key=True, default=uuid.uuid4)
-    conversation_id = Column(
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
         ForeignKey("conversation.id", ondelete="CASCADE"),
         nullable=False,
     )
-    user_id = Column(
+    user_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
         ForeignKey("neon_auth.user.id"),
         nullable=False,
     )
-    content = Column(Text, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
     type: Mapped[MessageType] = mapped_column(SQLEnum(MessageType), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/models/message.py
+++ b/src/models/message.py
@@ -20,25 +20,21 @@ class Message(Base):
     conversation_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
         ForeignKey("conversation.id", ondelete="CASCADE"),
-        nullable=False,
     )
     user_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
         ForeignKey("neon_auth.user.id"),
-        nullable=False,
     )
-    content: Mapped[str] = mapped_column(Text, nullable=False)
-    type: Mapped[MessageType] = mapped_column(SQLEnum(MessageType), nullable=False)
+    content: Mapped[str] = mapped_column(Text)
+    type: Mapped[MessageType] = mapped_column(SQLEnum(MessageType))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
-        nullable=False,
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
-        nullable=False,
     )
     __table_args__ = (
         Index("ix_message_conversation_created_at", "conversation_id", "created_at"),

--- a/src/models/sentiment.py
+++ b/src/models/sentiment.py
@@ -1,8 +1,7 @@
 import uuid
-from .base import Base
+
 from sqlalchemy import (
     UUID,
-    Column,
     Numeric,
     ForeignKey,
     Index,
@@ -10,11 +9,12 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
+from .base import Base
+
 
 class Sentiment(Base):
     __tablename__ = "sentiment"
-    id = Column(UUID, primary_key=True, default=uuid.uuid4)
-    conversation_id = Column(
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
         ForeignKey("conversation.id"),
         nullable=False,

--- a/src/models/sentiment.py
+++ b/src/models/sentiment.py
@@ -16,7 +16,7 @@ class Sentiment(Base):
     __tablename__ = "sentiment"
     conversation_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
-        ForeignKey("conversation.id"),
+        ForeignKey("conversation.id", ondelete="CASCADE"),
         nullable=False,
     )
     sentiment: Mapped[float] = mapped_column(

--- a/src/models/sentiment.py
+++ b/src/models/sentiment.py
@@ -17,11 +17,9 @@ class Sentiment(Base):
     conversation_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
         ForeignKey("conversation.id", ondelete="CASCADE"),
-        nullable=False,
     )
     sentiment: Mapped[float] = mapped_column(
         Numeric(4, 2, asdecimal=False),
-        nullable=False,
         default=0.00,
     )
     __table_args__ = (

--- a/src/models/summary.py
+++ b/src/models/summary.py
@@ -18,21 +18,13 @@ class Summary(Base):
     conversation_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
         ForeignKey("conversation.id", ondelete="CASCADE"),
-        nullable=False,
         unique=True,
     )
-    content: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content: Mapped[str | None] = mapped_column(Text)
     token_count: Mapped[int] = mapped_column(
         Integer,
         default=0,
         server_default="0",
-        nullable=False,
     )
-    window_start: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True),
-        nullable=True,
-    )
-    window_end: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True),
-        nullable=True,
-    )
+    window_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    window_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/src/models/summary.py
+++ b/src/models/summary.py
@@ -1,8 +1,8 @@
 import uuid
 from datetime import datetime
+
 from sqlalchemy import (
     UUID,
-    Column,
     Integer,
     Text,
     DateTime,
@@ -15,8 +15,7 @@ from .base import Base
 
 class Summary(Base):
     __tablename__ = "summary"
-    id = Column(UUID, primary_key=True, default=uuid.uuid4)
-    conversation_id = Column(
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
         UUID,
         ForeignKey("conversation.id", ondelete="CASCADE"),
         nullable=False,

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,10 +1,8 @@
 """User model STUB to allow for foreign key relationships in Message model."""
 
-from sqlalchemy import UUID, Column
 from .base import Base
 
 
 class User(Base):
     __tablename__ = "user"
     __table_args__ = {"schema": "neon_auth"}
-    id = Column(UUID, primary_key=True)


### PR DESCRIPTION
On the previous compaction branch, tightening one function signature (update_summary → datetime | None)
produced a cascade of type errors because Message.created_at was statically Column[datetime] rather than
datetime. Rather than fix that cascade locally, this PR migrates every model so reading an attribute yields
its real Python type. Any future typed signature elsewhere in the codebase now works without re-opening this
pattern. This is also the modern way of using sqlalchemy models.

Migrates all model column declarations from bare Column(...) to Mapped[T] = mapped_column(...) (SQLAlchemy
2.0 typed form).
Consolidates the primary key into Base. Five subclasses were each redeclaring their own id; Base now owns
the typed Mapped[uuid.UUID] with default=uuid.uuid4, and subclasses inherit.
Widens order_by in BaseCRUDRepository.get_all_by_field from ColumnElement to ColumnExpressionArgument[Any]
so Mapped[] attributes (which surface as InstrumentedAttribute) can be passed to it.