### PR TITLE
Housekeeping 2

### DIFF
--- a/src/service/agent_service.py
+++ b/src/service/agent_service.py
@@ -15,6 +15,7 @@ from pydantic_ai import (
     UserPromptPart,
 )
 from pydantic import ValidationError
+from src.exceptions.context_load_exception import ContextLoadException
 from src.middlewares.events import add_event_context, wide_event
 from src.schemas.message_model import Message
 from src.schemas.persona_model import Persona
@@ -93,7 +94,13 @@ class AgentService:
                 Message.model_validate(msg, from_attributes=True) for msg in db_messages
             ]
         except ValidationError as ve:
-            raise Exception(f"Validation error in message history: {ve}") from ve
+            raise ContextLoadException(
+                message="Failed to load conversation history: message data did not match schema",
+                details={
+                    "conversation_id": conversation_id,
+                    "validation_errors": ve.errors(),
+                },
+            ) from ve
 
     @wide_event("save_user_message")
     async def save_user_message(


### PR DESCRIPTION
What

In src/service/agent_service.py, load_history previously wrapped Pydantic ValidationError in a bare raise Exception(f"Validation error in message history: {ve}"). Replaced it with the project's existing ContextLoadException, passing structured details (conversation_id, ve.errors()) and preserving the cause chain via from ve.                                                                                          
                  
Why

- The bare Exception bypassed the AppException → global_exception_handler path, so clients got the generic INTERNAL_ERROR / 500 response and wide events were bucketed under error_category: server_error alongside every other unexpected failure — impossible to alert on this specific failure mode.
- ContextLoadException already existed for exactly this case (its docstring covers "conversation history fail to load into agent context") but wasn't being used.
- Interpolating ve into a string destroyed Pydantic's structured error data. Using ve.errors() in details keeps field paths, error types, and offending values queryable in Axiom.

Result

Failures from this path now emit error_code: CONTEXT_LOAD_ERROR with structured conversation_id and validation_errors fields on both the client response and the wide event, while the underlying ValidationError remains attached as __cause__ in tracebacks.