### PR TITLE
Housekeeping 3

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,8 +11,8 @@ from src.middlewares.events import EventMiddleware
 from src.middlewares.logging import setup_logger
 
 # Reduce uvicorn and starlette errors logging levels to avoid cluttering logs
-logging.getLogger("uvicorn.error").setLevel(logging.CRITICAL)
-logging.getLogger("starlette.middleware.errors").setLevel(logging.CRITICAL)
+logging.getLogger("uvicorn.error").setLevel(logging.WARNING)
+logging.getLogger("starlette.middleware.errors").setLevel(logging.WARNING)
 
 
 @asynccontextmanager


### PR DESCRIPTION
What                                                                                                                                                                                                                                                                                                                                                                                                                            
   
In src/main.py, changed the two module-level logger overrides from CRITICAL to WARNING:                                                                                                                                                                                                                                                                                                                                         
                  
- logging.getLogger("uvicorn.error").setLevel(logging.WARNING)
- logging.getLogger("starlette.middleware.errors").setLevel(logging.WARNING)

Why

CRITICAL was over-suppressing. Both loggers carry diagnostic signals the app can't recover from other sources:

- uvicorn.error emits lifespan failures at ERROR (e.g. "Application startup failed", engine.dispose() crashes in lifespan, TLS and protocol errors). These occur before any request exists, so wide events can't capture them. At CRITICAL they were silently dropped a failed deploy would show no explanation in logs.
- starlette.middleware.errors is ServerErrorMiddleware, the outermost middleware in this app's stack. Because EventMiddleware and CorrelationIDMiddleware sit outside ExceptionMiddleware, any exception in those middlewares — or in global_exception_handler itself — bypasses the wide-event path entirely and hits ServerErrorMiddleware's traceback log as the last line of defense. At CRITICAL that traceback was silenced, meaning a bug in our own observability code would produce 500s with no wide event and no stack trace.

WARNING keeps those signals (both log at ERROR when something is actually wrong) while still suppressing routine INFO lifecycle chatter that the original comment was targeting.

Result

Startup failures, lifespan exceptions, and last-resort tracebacks for errors escaping the middleware stack are now visible. Per-request handler failures are still covered by the existing wide-event pipeline, so there's no new duplication in the happy path.